### PR TITLE
Fix name of repo in github action example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
     name: Notify Slack on Release
     steps:
       - name: Notify Slack on Release
-        uses: instantish/notify-slack-on-release@1.0.0
+        uses: tryfabric/notify-slack-on-release@1.0.0
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```


### PR DESCRIPTION
The example code is broken, causing confusion when using the github action.